### PR TITLE
修正前言章节丢失

### DIFF
--- a/txt2mobi3/txt2html3.py
+++ b/txt2mobi3/txt2html3.py
@@ -133,6 +133,7 @@ class Book:
         if self._chapterization:
             idx = 1
             chapter = Chapter('前言', 0)
+            self._chapters.append(chapter)
             for line in lines:
                 if self._is_chapter_title(line):
                     chapter = Chapter(line.strip(), idx)


### PR DESCRIPTION
前言章节没有加到章节列表，因此从文章开头到第一个章节的内容会丢失。  
修正了这个bug。